### PR TITLE
Enums Refactoring.

### DIFF
--- a/BricklinkSharp.Client.Tests/BricklinkClientTests.cs
+++ b/BricklinkSharp.Client.Tests/BricklinkClientTests.cs
@@ -27,6 +27,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using BricklinkSharp.Client.CurrencyRates;
+using BricklinkSharp.Client.Enums;
 using NUnit.Framework;
 
 namespace BricklinkSharp.Client.Tests

--- a/BricklinkSharp.Client.Tests/Extensions/EnumExtensionsTests.cs
+++ b/BricklinkSharp.Client.Tests/Extensions/EnumExtensionsTests.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 using NUnit.Framework;
 
@@ -31,16 +32,220 @@ namespace BricklinkSharp.Client.Tests.Extensions
     public class EnumExtensionsTests
     {
         [Test]
-        public void GetStringValueOrDefault_ItemType()
+        public void ToDomainString_ItemType()
         {
-            Assert.AreEqual("minifig", ItemType.Minifig.GetStringValueOrDefault());
-            Assert.AreEqual("part", ItemType.Part.GetStringValueOrDefault());
-            Assert.AreEqual("book", ItemType.Book.GetStringValueOrDefault());
-            Assert.AreEqual("catalog", ItemType.Catalog.GetStringValueOrDefault());
-            Assert.AreEqual("gear", ItemType.Gear.GetStringValueOrDefault());
-            Assert.AreEqual("instruction", ItemType.Instruction.GetStringValueOrDefault());
-            Assert.AreEqual("original_box", ItemType.OriginalBox.GetStringValueOrDefault());
-            Assert.AreEqual("unsorted_lot", ItemType.UnsortedLot.GetStringValueOrDefault());
+            Assert.AreEqual("minifig", ItemType.Minifig.ToDomainString());
+            Assert.AreEqual("part", ItemType.Part.ToDomainString());
+            Assert.AreEqual("book", ItemType.Book.ToDomainString());
+            Assert.AreEqual("catalog", ItemType.Catalog.ToDomainString());
+            Assert.AreEqual("gear", ItemType.Gear.ToDomainString());
+            Assert.AreEqual("instruction", ItemType.Instruction.ToDomainString());
+            Assert.AreEqual("original_box", ItemType.OriginalBox.ToDomainString());
+            Assert.AreEqual("unsorted_lot", ItemType.UnsortedLot.ToDomainString());
+            ItemType? itemType = null;
+            Assert.IsNull(itemType?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_PartOutItemType()
+        {
+            Assert.AreEqual("M", PartOutItemType.Minifig.ToDomainString());
+            Assert.AreEqual("G", PartOutItemType.Gear.ToDomainString());
+            Assert.AreEqual("S", PartOutItemType.Set.ToDomainString());
+
+            PartOutItemType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_OrderStatus()
+        {
+            Assert.AreEqual("PENDING", OrderStatus.Pending.ToDomainString());
+            Assert.AreEqual("UPDATED", OrderStatus.Updated.ToDomainString());
+            Assert.AreEqual("PROCESSING", OrderStatus.Processing.ToDomainString());
+            Assert.AreEqual("READY", OrderStatus.Ready.ToDomainString());
+            Assert.AreEqual("PAID", OrderStatus.Paid.ToDomainString());
+            Assert.AreEqual("PACKED", OrderStatus.Packed.ToDomainString());
+            Assert.AreEqual("SHIPPED", OrderStatus.Shipped.ToDomainString());
+            Assert.AreEqual("RECEIVED", OrderStatus.Received.ToDomainString());
+            Assert.AreEqual("COMPLETED", OrderStatus.Completed.ToDomainString());
+            Assert.AreEqual("OCR", OrderStatus.Ocr.ToDomainString());
+            Assert.AreEqual("NPB", OrderStatus.Npb.ToDomainString());
+            Assert.AreEqual("NPX", OrderStatus.Npx.ToDomainString());
+            Assert.AreEqual("NRS", OrderStatus.Nrs.ToDomainString());
+            Assert.AreEqual("NSS", OrderStatus.Nss.ToDomainString());
+            Assert.AreEqual("CANCELLED", OrderStatus.Cancelled.ToDomainString());
+            Assert.AreEqual("PURGED", OrderStatus.Purged.ToDomainString());
+
+            OrderStatus? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_Condition()
+        {
+            Assert.AreEqual("N", Condition.New.ToDomainString());
+            Assert.AreEqual("U", Condition.Used.ToDomainString());
+
+            Condition? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_PriceGuideType()
+        {
+            Assert.AreEqual("sold", PriceGuideType.Sold.ToDomainString());
+            Assert.AreEqual("stock", PriceGuideType.Stock.ToDomainString());
+
+            PriceGuideType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_OrderDirection()
+        {
+            Assert.AreEqual("in", OrderDirection.In.ToDomainString());
+            Assert.AreEqual("out", OrderDirection.Out.ToDomainString());
+
+            OrderDirection? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_Direction()
+        {
+            Assert.AreEqual("in", Direction.In.ToDomainString());
+            Assert.AreEqual("out", Direction.Out.ToDomainString());
+
+            Direction? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_InventoryStatusType()
+        {
+            Assert.AreEqual("Y", InventoryStatusType.Available.ToDomainString());
+            Assert.AreEqual("S", InventoryStatusType.InStockRoomA.ToDomainString());
+            Assert.AreEqual("B", InventoryStatusType.InStockRoomB.ToDomainString());
+            Assert.AreEqual("C", InventoryStatusType.InStockRoomC.ToDomainString());
+            Assert.AreEqual("N", InventoryStatusType.Unavailable.ToDomainString());
+            Assert.AreEqual("R", InventoryStatusType.Reserved.ToDomainString());
+
+            InventoryStatusType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_CouponStatus()
+        {
+            Assert.AreEqual("O", CouponStatus.Open.ToDomainString());
+            Assert.AreEqual("A", CouponStatus.Redeemed.ToDomainString());
+            Assert.AreEqual("D", CouponStatus.Declined.ToDomainString());
+            Assert.AreEqual("E", CouponStatus.Expired.ToDomainString());
+
+            CouponStatus? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_ShippingArea()
+        {
+            Assert.AreEqual("D", ShippingArea.Domestic.ToDomainString());
+            Assert.AreEqual("I", ShippingArea.International.ToDomainString());
+            Assert.AreEqual("B", ShippingArea.Both.ToDomainString());
+
+            ShippingArea? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_AppearsAs()
+        {
+            Assert.AreEqual("R", AppearsAs.Regular.ToDomainString());
+            Assert.AreEqual("A", AppearsAs.Alternate.ToDomainString());
+            Assert.AreEqual("C", AppearsAs.Counterpart.ToDomainString());
+            Assert.AreEqual("E", AppearsAs.Extra.ToDomainString());
+
+            AppearsAs? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_RatingTargeRole()
+        {
+            Assert.AreEqual("S", RatingTargeRole.Seller.ToDomainString());
+            Assert.AreEqual("B", RatingTargeRole.Buyer.ToDomainString());
+
+            RatingTargeRole? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_DiscountType()
+        {
+            Assert.AreEqual("F", DiscountType.Fixed.ToDomainString());
+            Assert.AreEqual("S", DiscountType.Percentage.ToDomainString());
+
+            DiscountType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_Completeness()
+        {
+            Assert.AreEqual("C", Completeness.Complete.ToDomainString());
+            Assert.AreEqual("B", Completeness.Incomplete.ToDomainString());
+            Assert.AreEqual("S", Completeness.Sealed.ToDomainString());
+
+            Completeness? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_CouponRestrictionType()
+        {
+            Assert.AreEqual("A", CouponRestrictionType.ApplyToSpecifiedItemType.ToDomainString());
+            Assert.AreEqual("E", CouponRestrictionType.ExcludeSpecifiedType.ToDomainString());
+
+            CouponRestrictionType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_EventType()
+        {
+            Assert.AreEqual("Order", EventType.Order.ToDomainString());
+            Assert.AreEqual("Message", EventType.Message.ToDomainString());
+            Assert.AreEqual("Feedback", EventType.Feedback.ToDomainString());
+
+            EventType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_RatingType()
+        {
+            Assert.AreEqual("Complaint", RatingType.Complaint.ToDomainString());
+            Assert.AreEqual("Neutral", RatingType.Neutral.ToDomainString());
+            Assert.AreEqual("Praise", RatingType.Praise.ToDomainString());
+
+            RatingType? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
+        }
+
+        [Test]
+        public void ToDomainString_PaymentStatus()
+        {
+            Assert.AreEqual("Bounced", PaymentStatus.Bounced.ToDomainString());
+            Assert.AreEqual("Clearing", PaymentStatus.Clearing.ToDomainString());
+            Assert.AreEqual("Completed", PaymentStatus.Completed.ToDomainString());
+            Assert.AreEqual("None", PaymentStatus.None.ToDomainString());
+            Assert.AreEqual("Received", PaymentStatus.Received.ToDomainString());
+            Assert.AreEqual("Returned", PaymentStatus.Returned.ToDomainString());
+            Assert.AreEqual("Sent", PaymentStatus.Sent.ToDomainString());
+
+            PaymentStatus? nullHolder = null;
+            Assert.IsNull(nullHolder?.ToDomainString());
         }
     }
 }

--- a/BricklinkSharp.Client/BricklinkClient.cs
+++ b/BricklinkSharp.Client/BricklinkClient.cs
@@ -37,6 +37,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Web;
 using BricklinkSharp.Client.CurrencyRates;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 using BricklinkSharp.Client.OAuth;
 
@@ -243,7 +244,7 @@ namespace BricklinkSharp.Client
 
         public async Task<CatalogItem> GetItemAsync(ItemType type, string no, CancellationToken cancellationToken)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
             var url = new Uri(_baseUri, $"items/{typeString}/{no}").ToString();
 
             var method = HttpMethod.Get;
@@ -255,7 +256,7 @@ namespace BricklinkSharp.Client
 
         public async Task<CatalogImage> GetItemImageAsync(ItemType type, string no, int colorId, CancellationToken cancellationToken)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
             var url = new Uri(_baseUri, $"items/{typeString}/{no}/images/{colorId}").ToString();
 
             var method = HttpMethod.Get;
@@ -313,7 +314,7 @@ namespace BricklinkSharp.Client
         public async Task<Superset[]> GetSupersetsAsync(ItemType type, string no,
             int colorId = 0, CancellationToken cancellationToken = default)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
 
             var url = new Uri(_baseUri,
                 colorId > 0 ?
@@ -332,7 +333,7 @@ namespace BricklinkSharp.Client
             bool? includeInstruction = null, bool? breakMinifigs = null, bool? breakSubsets = null,
             CancellationToken cancellationToken = default)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
             var builder = new UriBuilder(new Uri(_baseUri, $"items/{typeString}/{no}/subsets"));
             var query = HttpUtility.ParseQueryString(builder.Query);
             query["color_id"] = colorId.ToString();
@@ -355,12 +356,12 @@ namespace BricklinkSharp.Client
             string? countryCode = null, string? region = null, string? currencyCode = null,
             CancellationToken cancellationToken = default)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
             var builder = new UriBuilder(new Uri(_baseUri, $"items/{typeString}/{no}/price"));
             var query = HttpUtility.ParseQueryString(builder.Query);
             query["color_id"] = colorId.ToString();
-            query.AddIfNotNull("guide_type", priceGuideType, pg => pg!.ToString().ToLower());
-            query.AddIfNotNull("new_or_used", condition, c => c!.GetStringValueOrDefault());
+            query.AddIfNotNull("guide_type", priceGuideType?.ToDomainString());
+            query.AddIfNotNull("new_or_used", condition?.ToDomainString());
 
             query.AddIfNotNull("country_code", countryCode);
             query.AddIfNotNull("region", region);
@@ -378,7 +379,7 @@ namespace BricklinkSharp.Client
         public async Task<KnownColor[]> GetKnownColorsAsync(ItemType type, string no,
             CancellationToken cancellationToken = default)
         {
-            var typeString = type.GetStringValueOrDefault();
+            var typeString = type.ToDomainString();
             var url = new Uri(_baseUri, $"items/{typeString}/{no}/colors").ToString();
 
             var method = HttpMethod.Get;
@@ -441,8 +442,8 @@ namespace BricklinkSharp.Client
         {
             var builder = new UriBuilder(new Uri(_baseUri, "inventories"));
             var query = HttpUtility.ParseQueryString(builder.Query);
-            query.AddIfNotNull("item_type", BuildIncludeExcludeParameter(includedItemTypes, excludedItemTypes, t => t.GetStringValueOrDefault()));
-            query.AddIfNotNull("status", BuildIncludeExcludeParameter(includedStatusFlags, excludedStatusFlags, f => f.GetStringValueOrDefault()));
+            query.AddIfNotNull("item_type", BuildIncludeExcludeParameter(includedItemTypes, excludedItemTypes, t => t.ToDomainString()));
+            query.AddIfNotNull("status", BuildIncludeExcludeParameter(includedStatusFlags, excludedStatusFlags, f => f.ToDomainString()));
             query.AddIfNotNull("category_id", BuildIncludeExcludeParameter(includedCategoryIds, excludedCategoryIds, categoryId => categoryId.ToString()));
             query.AddIfNotNull("color_id", BuildIncludeExcludeParameter(includedColorIds, excludedColorIds, colorId => colorId.ToString()));
             builder.Query = query.ToString();
@@ -634,8 +635,8 @@ namespace BricklinkSharp.Client
         {
             var builder = new UriBuilder(new Uri(_baseUri, "orders"));
             var query = HttpUtility.ParseQueryString(builder.Query);
-            query.Add("direction", direction.GetStringValueOrDefault());
-            query.AddIfNotNull("status", BuildIncludeExcludeParameter(includedStatusFlags, excludedStatusFlags, f => f.GetStringValueOrDefault()));
+            query.Add("direction", direction.ToDomainString());
+            query.AddIfNotNull("status", BuildIncludeExcludeParameter(includedStatusFlags, excludedStatusFlags, f => f.ToDomainString()));
             query.Add("filed", filed.ToString());
             builder.Query = query.ToString();
             var url = builder.ToString();
@@ -708,7 +709,7 @@ namespace BricklinkSharp.Client
             var responseBody = await ExecuteRequest(url, method, new
             {
                 field = "status",
-                value = status.GetStringValueOrDefault()
+                value = status.ToDomainString()
             }, cancellationToken: cancellationToken);
 
             ParseResponseNoData(responseBody, 200, url, method);
@@ -723,7 +724,7 @@ namespace BricklinkSharp.Client
             var responseBody = await ExecuteRequest(url, method, new
             {
                 field = "payment_status",
-                value = status.ToString()
+                value = status.ToDomainString()
             }, cancellationToken: cancellationToken);
 
             ParseResponseNoData(responseBody, 200, url, HttpMethod.Put);
@@ -770,11 +771,11 @@ namespace BricklinkSharp.Client
         {
             var builder = new UriBuilder(new Uri(_baseUri, "coupons"));
             var query = HttpUtility.ParseQueryString(builder.Query);
-            query.Add("direction", direction.GetStringValueOrDefault());
+            query.Add("direction", direction.ToDomainString());
 
             query.AddIfNotNull("status", BuildIncludeExcludeParameter(includedCouponStatusTypes,
                 excludedCouponStatusTypes,
-                f => f.GetStringValueOrDefault()));
+                f => f.ToDomainString()));
 
             builder.Query = query.ToString();
             var url = builder.ToString();
@@ -850,9 +851,11 @@ namespace BricklinkSharp.Client
                 sequenceNumber = temp;
             }
 
+            var s = condition.ToDomainString();
+
             var url = "https://www.bricklink.com/catalogPOV.asp?" +
-                      $"itemType={itemType.GetStringValueOrDefault()}&itemNo={rawItemNumber}&itemSeq={sequenceNumber}&itemQty=1&" +
-                      $"breakType={(breakMinifigs ? "P" : "M")}&itemCondition={condition.GetStringValueOrDefault()}" +
+                      $"itemType={itemType.ToDomainString()}&itemNo={rawItemNumber}&itemSeq={sequenceNumber}&itemQty=1&" +
+                      $"breakType={(breakMinifigs ? "P" : "M")}&itemCondition={condition.ToDomainString()}" +
                       $"&incInstr={(includeInstructions ? "Y" : "N")}&incBox={(includeBox ? "Y" : "N")}&" +
                       $"incParts={(includeExtraParts ? "Y" : "N")}&breakSets={(breakSetsInSet ? "Y" : "N")}";
 

--- a/BricklinkSharp.Client/Coupon.cs
+++ b/BricklinkSharp.Client/Coupon.cs
@@ -23,9 +23,10 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-using BricklinkSharp.Client.Json;
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
+using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client
 {

--- a/BricklinkSharp.Client/CouponAppliesTo.cs
+++ b/BricklinkSharp.Client/CouponAppliesTo.cs
@@ -23,9 +23,10 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-using BricklinkSharp.Client.Json;
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
+using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client
 {

--- a/BricklinkSharp.Client/CouponBase.cs
+++ b/BricklinkSharp.Client/CouponBase.cs
@@ -23,11 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-using BricklinkSharp.Client.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
+using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client
 {

--- a/BricklinkSharp.Client/Enums/AppearsAs.cs
+++ b/BricklinkSharp.Client/Enums/AppearsAs.cs
@@ -23,12 +23,13 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum RatingType
+    public enum AppearsAs
     {
-        Praise = 0,
-        Neutral = 1,
-        Complaint = 2
+        Regular = 0,
+        Alternate = 1,
+        Counterpart = 2,
+        Extra = 3
     }
 }

--- a/BricklinkSharp.Client/Enums/Completeness.cs
+++ b/BricklinkSharp.Client/Enums/Completeness.cs
@@ -23,15 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum CouponRestrictionType
+    public enum Completeness
     {
-        [StringValue("A")]
-        ApplyToSpecifiedItemType = 0,
-
-        [StringValue("E")]
-        ExcludeSpecifiedType = 1
+        Complete = 0,
+        Incomplete = 1,
+        Sealed = 2
     }
 }

--- a/BricklinkSharp.Client/Enums/Condition.cs
+++ b/BricklinkSharp.Client/Enums/Condition.cs
@@ -23,11 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum Direction
+    public enum Condition
     {
-        Out = 1,
-        In = 0
+        New = 0,
+        Used = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/CouponRestrictionType.cs
+++ b/BricklinkSharp.Client/Enums/CouponRestrictionType.cs
@@ -23,19 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-using System;
-
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    [AttributeUsage(AttributeTargets.Field)]
-    [Serializable]
-    internal class StringValueAttribute : Attribute
+    public enum CouponRestrictionType
     {
-        public string Value { get; }
-
-        public StringValueAttribute(string value)
-        {
-            Value = value;
-        }
+        ApplyToSpecifiedItemType = 0,
+        ExcludeSpecifiedType = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/CouponStatus.cs
+++ b/BricklinkSharp.Client/Enums/CouponStatus.cs
@@ -23,17 +23,13 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum ShippingArea
+    public enum CouponStatus
     {
-        [StringValue("D")]
-        Domestic = 0,
-
-        [StringValue("I")]
-        International = 1,
-
-        [StringValue("B")]
-        Both = 2
+        Open = 0,
+        Redeemed = 1,
+        Declined = 2,
+        Expired = 3
     }
 }

--- a/BricklinkSharp.Client/Enums/Direction.cs
+++ b/BricklinkSharp.Client/Enums/Direction.cs
@@ -23,56 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum OrderStatus
+    public enum Direction
     {
-        [StringValue("PENDING")]
-        Pending = 0,
-
-        [StringValue("UPDATED")]
-        Updated = 1,
-
-        [StringValue("PROCESSING")]
-        Processing = 2,
-
-        [StringValue("READY")]
-        Ready = 3,
-
-        [StringValue("PAID")]
-        Paid = 4,
-
-        [StringValue("PACKED")]
-        Packed = 5,
-
-        [StringValue("SHIPPED")]
-        Shipped = 6,
-
-        [StringValue("RECEIVED")]
-        Received = 7,
-
-        [StringValue("COMPLETED")]
-        Completed = 8,
-
-        [StringValue("OCR")]
-        Ocr = 9,
-
-        [StringValue("NPB")]
-        Npb = 10,
-
-        [StringValue("NPX")]
-        Npx = 11,
-
-        [StringValue("NRS")]
-        Nrs = 12,
-
-        [StringValue("NSS")]
-        Nss = 13,
-
-        [StringValue("CANCELLED")]
-        Cancelled = 14,
-
-        [StringValue("PURGED")]
-        Purged = 15
+        Out = 1,
+        In = 0
     }
 }

--- a/BricklinkSharp.Client/Enums/DiscountType.cs
+++ b/BricklinkSharp.Client/Enums/DiscountType.cs
@@ -23,16 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum PaymentStatus
+    public enum DiscountType
     {
-        None = 0,
-        Sent = 1,
-        Received = 2,
-        Clearing = 3,
-        Returned = 4,
-        Bounced = 5,
-        Completed = 6
+        Fixed = 0,
+        Percentage = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/InventoryStatusType.cs
+++ b/BricklinkSharp.Client/Enums/InventoryStatusType.cs
@@ -23,11 +23,15 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum OrderDirection
+    public enum InventoryStatusType
     {
-        In = 0,
-        Out = 1
+        Available = 0,
+        InStockRoomA = 1,
+        InStockRoomB = 2,
+        InStockRoomC = 3,
+        Unavailable = 4,
+        Reserved = 5
     }
 }

--- a/BricklinkSharp.Client/Enums/ItemType.cs
+++ b/BricklinkSharp.Client/Enums/ItemType.cs
@@ -23,47 +23,18 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum PartOutItemType
-    {
-        [StringValue("S")]
-        Set = 0,
-
-        [StringValue("M")]
-        Minifig = 1,
-
-        [StringValue("G")]
-        Gear = 2,
-    }
-
     public enum ItemType
     {
-        [StringValue("minifig")]
         Minifig = 0,
-
-        [StringValue("part")]
         Part = 1,
-
-        [StringValue("set")]
         Set = 2,
-
-        [StringValue("book")]
         Book = 3,
-
-        [StringValue("gear")]
         Gear = 4,
-
-        [StringValue("catalog")]
         Catalog = 5,
-
-        [StringValue("instruction")]
         Instruction = 6,
-
-        [StringValue("unsorted_lot")]
         UnsortedLot = 7,
-
-        [StringValue("original_box")]
         OriginalBox = 8
     }
 }

--- a/BricklinkSharp.Client/Enums/OrderDirection.cs
+++ b/BricklinkSharp.Client/Enums/OrderDirection.cs
@@ -23,17 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum Completeness
+    public enum OrderDirection
     {
-        [StringValue("C")]
-        Complete = 0,
-
-        [StringValue("B")]
-        Incomplete = 1,
-
-        [StringValue("S")]
-        Sealed = 2
+        In = 0,
+        Out = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/OrderStatus.cs
+++ b/BricklinkSharp.Client/Enums/OrderStatus.cs
@@ -23,21 +23,25 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum CouponStatus
+    public enum OrderStatus
     {
-        [StringValue("O")]
-        Open = 0,
-
-        [StringValue("A")]
-        Redeemed = 1,
-
-        [StringValue("D")]
-        Declined = 2,
-
-        [StringValue("E")]
-        Expired = 3
+        Pending = 0,
+        Updated = 1,
+        Processing = 2,
+        Ready = 3,
+        Paid = 4,
+        Packed = 5,
+        Shipped = 6,
+        Received = 7,
+        Completed = 8,
+        Ocr = 9,
+        Npb = 10,
+        Npx = 11,
+        Nrs = 12,
+        Nss = 13,
+        Cancelled = 14,
+        Purged = 15
     }
 }

--- a/BricklinkSharp.Client/Enums/PartOutItemType.cs
+++ b/BricklinkSharp.Client/Enums/PartOutItemType.cs
@@ -23,20 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum AppearsAs
+    public enum PartOutItemType
     {
-        [StringValue("R")]
-        Regular = 0,
-
-        [StringValue("A")]
-        Alternate = 1,
-
-        [StringValue("C")]
-        Counterpart = 2,
-
-        [StringValue("E")]
-        Extra = 3
+        Set = 0,
+        Minifig = 1,
+        Gear = 2,
     }
 }

--- a/BricklinkSharp.Client/Enums/PaymentStatus.cs
+++ b/BricklinkSharp.Client/Enums/PaymentStatus.cs
@@ -23,17 +23,16 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum EventType
+    public enum PaymentStatus
     {
-        [StringValue("Order")]
-        Order = 0,
-
-        [StringValue("Message")]
-        Message = 1,
-
-        [StringValue("Feedback")]
-        Feedback = 2
+        None = 0,
+        Sent = 1,
+        Received = 2,
+        Clearing = 3,
+        Returned = 4,
+        Bounced = 5,
+        Completed = 6
     }
 }

--- a/BricklinkSharp.Client/Enums/PriceGuideType.cs
+++ b/BricklinkSharp.Client/Enums/PriceGuideType.cs
@@ -23,14 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum Condition
+    public enum PriceGuideType
     {
-        [StringValue("N")]
-        New = 0,
-
-        [StringValue("U")]
-        Used = 1
+        Sold = 0,
+        Stock = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/RatingTargeRole.cs
+++ b/BricklinkSharp.Client/Enums/RatingTargeRole.cs
@@ -23,11 +23,11 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum PriceGuideType
+    public enum RatingTargeRole
     {
-        Sold = 0,
-        Stock = 1
+        Seller = 0,
+        Buyer = 1
     }
 }

--- a/BricklinkSharp.Client/Enums/RatingType.cs
+++ b/BricklinkSharp.Client/Enums/RatingType.cs
@@ -23,14 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum RatingTargeRole
+    public enum RatingType
     {
-        [StringValue("S")]
-        Seller = 0,
-
-        [StringValue("B")]
-        Buyer = 1
+        Praise = 0,
+        Neutral = 1,
+        Complaint = 2
     }
 }

--- a/BricklinkSharp.Client/Enums/ShippingArea.cs
+++ b/BricklinkSharp.Client/Enums/ShippingArea.cs
@@ -23,26 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum InventoryStatusType
+    public enum ShippingArea
     {
-        [StringValue("Y")]
-        Available = 0,
-
-        [StringValue("S")]
-        InStockRoomA = 1,
-
-        [StringValue("B")]
-        InStockRoomB = 2,
-
-        [StringValue("C")]
-        InStockRoomC = 3,
-
-        [StringValue("N")]
-        Unavailable = 4,
-
-        [StringValue("R")]
-        Reserved = 5
+        Domestic = 0,
+        International = 1,
+        Both = 2
     }
 }

--- a/BricklinkSharp.Client/Extensions/EnumExtensions.cs
+++ b/BricklinkSharp.Client/Extensions/EnumExtensions.cs
@@ -24,34 +24,229 @@
 #endregion
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Client.Extensions
 {
     internal static class EnumExtensions
     {
-        private static readonly IDictionary<Enum, string> _stringValueCache = new ConcurrentDictionary<Enum, string>();
-
-        private static T? GetAttributeOfType<T>(this Enum enumVal) where T : Attribute
+        internal static string ToDomainString(this OrderStatus e)
         {
-            var type = enumVal.GetType();
-            var memInfo = type.GetMember(enumVal.ToString());
-            var attributes = memInfo[0].GetCustomAttributes(typeof(T), false);
-            return attributes.Length > 0 ? (T)attributes[0] : null;
+            return e switch
+            {
+                OrderStatus.Pending => nameof(OrderStatus.Pending).ToUpper(),
+                OrderStatus.Updated => nameof(OrderStatus.Updated).ToUpper(),
+                OrderStatus.Processing => nameof(OrderStatus.Processing).ToUpper(),
+                OrderStatus.Ready => nameof(OrderStatus.Ready).ToUpper(),
+                OrderStatus.Paid => nameof(OrderStatus.Paid).ToUpper(),
+                OrderStatus.Packed => nameof(OrderStatus.Packed).ToUpper(),
+                OrderStatus.Shipped => nameof(OrderStatus.Shipped).ToUpper(),
+                OrderStatus.Received => nameof(OrderStatus.Received).ToUpper(),
+                OrderStatus.Completed => nameof(OrderStatus.Completed).ToUpper(),
+                OrderStatus.Ocr => nameof(OrderStatus.Ocr).ToUpper(),
+                OrderStatus.Npb => nameof(OrderStatus.Npb).ToUpper(),
+                OrderStatus.Npx => nameof(OrderStatus.Npx).ToUpper(),
+                OrderStatus.Nrs => nameof(OrderStatus.Nrs).ToUpper(),
+                OrderStatus.Nss => nameof(OrderStatus.Nss).ToUpper(),
+                OrderStatus.Cancelled => nameof(OrderStatus.Cancelled).ToUpper(),
+                OrderStatus.Purged => nameof(OrderStatus.Purged).ToUpper(),
+                _ => throw new ArgumentOutOfRangeException(nameof(OrderStatus), e, null)
+            };
         }
 
-        internal static string GetStringValueOrDefault(this Enum e)
+        internal static string ToDomainString(this PartOutItemType e)
         {
-            if (_stringValueCache.ContainsKey(e))
+            return e switch
             {
-                return _stringValueCache[e];
-            }
+                PartOutItemType.Set => "S",
+                PartOutItemType.Minifig => "M",
+                PartOutItemType.Gear => "G",
+                _ => throw new ArgumentOutOfRangeException(nameof(PartOutItemType), e, null)
+            };
+        }
 
-            var attribute = GetAttributeOfType<StringValueAttribute>(e);
-            var stringValue = attribute?.Value ?? e.ToString();
-            _stringValueCache.Add(e, stringValue);
-            return stringValue;
+        internal static string ToDomainString(this ItemType e)
+        {
+            return e switch
+            {
+                ItemType.Minifig => nameof(ItemType.Minifig).ToLowerInvariant(),
+                ItemType.Part => nameof(ItemType.Part).ToLowerInvariant(),
+                ItemType.Set => nameof(ItemType.Set).ToLowerInvariant(),
+                ItemType.Book => nameof(ItemType.Book).ToLowerInvariant(),
+                ItemType.Gear => nameof(ItemType.Gear).ToLowerInvariant(),
+                ItemType.Catalog => nameof(ItemType.Catalog).ToLowerInvariant(),
+                ItemType.Instruction => nameof(ItemType.Instruction).ToLowerInvariant(),
+                ItemType.UnsortedLot => "unsorted_lot",
+                ItemType.OriginalBox => "original_box",
+                _ => throw new ArgumentOutOfRangeException(nameof(ItemType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this Condition e)
+        {
+            return e switch
+            {
+                Condition.New => "N",
+                Condition.Used => "U",
+                _ => throw new ArgumentOutOfRangeException(nameof(Condition), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this PriceGuideType e)
+        {
+            return e switch
+            {
+                PriceGuideType.Sold => nameof(PriceGuideType.Sold).ToLowerInvariant(),
+                PriceGuideType.Stock => nameof(PriceGuideType.Stock).ToLowerInvariant(),
+                _ => throw new ArgumentOutOfRangeException(nameof(PriceGuideType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this OrderDirection e)
+        {
+            return e switch
+            {
+                OrderDirection.In => nameof(OrderDirection.In).ToLowerInvariant(),
+                OrderDirection.Out => nameof(OrderDirection.Out).ToLowerInvariant(),
+                _ => throw new ArgumentOutOfRangeException(nameof(OrderDirection), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this Direction e)
+        {
+            return e switch
+            {
+                Direction.In => nameof(Direction.In).ToLowerInvariant(),
+                Direction.Out => nameof(Direction.Out).ToLowerInvariant(),
+                _ => throw new ArgumentOutOfRangeException(nameof(Direction), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this InventoryStatusType e)
+        {
+            return e switch
+            {
+                InventoryStatusType.Available => "Y",
+                InventoryStatusType.InStockRoomA => "S",
+                InventoryStatusType.InStockRoomB => "B",
+                InventoryStatusType.InStockRoomC => "C",
+                InventoryStatusType.Unavailable => "N",
+                InventoryStatusType.Reserved => "R",
+                _ => throw new ArgumentOutOfRangeException(nameof(InventoryStatusType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this CouponStatus e)
+        {
+            return e switch
+            {
+                CouponStatus.Open => "O",
+                CouponStatus.Redeemed => "A",
+                CouponStatus.Declined => "D",
+                CouponStatus.Expired => "E",
+                _ => throw new ArgumentOutOfRangeException(nameof(CouponStatus), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this ShippingArea e)
+        {
+            return e switch
+            {
+                ShippingArea.Domestic => "D",
+                ShippingArea.International => "I",
+                ShippingArea.Both => "B",
+                _ => throw new ArgumentOutOfRangeException(nameof(ShippingArea), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this AppearsAs e)
+        {
+            return e switch
+            {
+                AppearsAs.Regular => "R",
+                AppearsAs.Alternate => "A",
+                AppearsAs.Counterpart => "C",
+                AppearsAs.Extra => "E",
+                _ => throw new ArgumentOutOfRangeException(nameof(AppearsAs), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this RatingTargeRole e)
+        {
+            return e switch
+            {
+                RatingTargeRole.Seller => "S",
+                RatingTargeRole.Buyer => "B",
+                _ => throw new ArgumentOutOfRangeException(nameof(RatingTargeRole), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this DiscountType e)
+        {
+            return e switch
+            {
+                DiscountType.Fixed => "F",
+                DiscountType.Percentage => "S",
+                _ => throw new ArgumentOutOfRangeException(nameof(DiscountType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this Completeness e)
+        {
+            return e switch
+            {
+                Completeness.Complete => "C",
+                Completeness.Incomplete => "B",
+                Completeness.Sealed => "S",
+                _ => throw new ArgumentOutOfRangeException(nameof(Completeness), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this CouponRestrictionType e)
+        {
+            return e switch
+            {
+                CouponRestrictionType.ApplyToSpecifiedItemType => "A",
+                CouponRestrictionType.ExcludeSpecifiedType => "E",
+                _ => throw new ArgumentOutOfRangeException(nameof(CouponRestrictionType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this EventType e)
+        {
+            return e switch
+            {
+                EventType.Order => nameof(EventType.Order),
+                EventType.Message => nameof(EventType.Message),
+                EventType.Feedback => nameof(EventType.Feedback),
+                _ => throw new ArgumentOutOfRangeException(nameof(EventType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this RatingType e)
+        {
+            return e switch
+            {
+                RatingType.Praise => nameof(RatingType.Praise),
+                RatingType.Neutral => nameof(RatingType.Neutral),
+                RatingType.Complaint => nameof(RatingType.Complaint),
+                _ => throw new ArgumentOutOfRangeException(nameof(RatingType), e, null)
+            };
+        }
+
+        internal static string ToDomainString(this PaymentStatus e)
+        {
+            return e switch
+            {
+                PaymentStatus.Bounced => nameof(PaymentStatus.Bounced),
+                PaymentStatus.Clearing => nameof(PaymentStatus.Clearing),
+                PaymentStatus.Completed => nameof(PaymentStatus.Completed),
+                PaymentStatus.None => nameof(PaymentStatus.None),
+                PaymentStatus.Received => nameof(PaymentStatus.Received),
+                PaymentStatus.Returned => nameof(PaymentStatus.Returned),
+                PaymentStatus.Sent => nameof(PaymentStatus.Sent),
+                _ => throw new ArgumentOutOfRangeException(nameof(PaymentStatus), e, null)
+            };
         }
     }
 }

--- a/BricklinkSharp.Client/Feedback.cs
+++ b/BricklinkSharp.Client/Feedback.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 // ReSharper disable UnusedType.Global

--- a/BricklinkSharp.Client/FeedbackBase.cs
+++ b/BricklinkSharp.Client/FeedbackBase.cs
@@ -24,6 +24,7 @@
 #endregion
 
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/IBricklinkClient.cs
+++ b/BricklinkSharp.Client/IBricklinkClient.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using BricklinkSharp.Client.Enums;
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/BricklinkSharp.Client/InventoryBase.cs
+++ b/BricklinkSharp.Client/InventoryBase.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/ItemBase.cs
+++ b/BricklinkSharp.Client/ItemBase.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/Json/AppearsAsStringConverter.cs
+++ b/BricklinkSharp.Client/Json/AppearsAsStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -52,7 +53,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, AppearsAs value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/CompletenessStringConverter.cs
+++ b/BricklinkSharp.Client/Json/CompletenessStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -50,7 +51,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, Completeness value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/ConditionStringConverter.cs
+++ b/BricklinkSharp.Client/Json/ConditionStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -48,7 +49,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, Condition value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/CouponStatusStringConverter.cs
+++ b/BricklinkSharp.Client/Json/CouponStatusStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -47,7 +48,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, CouponStatus value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/DiscountTypeStringConverter.cs
+++ b/BricklinkSharp.Client/Json/DiscountTypeStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -48,7 +49,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, DiscountType value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/EventType.cs
+++ b/BricklinkSharp.Client/Json/EventType.cs
@@ -23,15 +23,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-
-namespace BricklinkSharp.Client
+namespace BricklinkSharp.Client.Enums
 {
-    public enum DiscountType
+    public enum EventType
     {
-        [StringValue("F")]
-        Fixed = 0,
-
-        [StringValue("S")]
-        Percentage = 1
+        Order = 0,
+        Message = 1,
+        Feedback = 2
     }
 }

--- a/BricklinkSharp.Client/Json/EventTypeStringConverter.cs
+++ b/BricklinkSharp.Client/Json/EventTypeStringConverter.cs
@@ -26,6 +26,8 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
+using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
 {
@@ -45,7 +47,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, EventType value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString());
+            writer.WriteStringValue(value.ToDomainString());
         }
     }
 }

--- a/BricklinkSharp.Client/Json/ItemTypeStringConverter.cs
+++ b/BricklinkSharp.Client/Json/ItemTypeStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -53,7 +54,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, ItemType value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString().ToUpperInvariant();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/NullableCouponRestrictionTypeStringConverter.cs
+++ b/BricklinkSharp.Client/Json/NullableCouponRestrictionTypeStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -56,7 +57,7 @@ namespace BricklinkSharp.Client.Json
                 return;
             }
 
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value?.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/NullableItemTypeStringConverter.cs
+++ b/BricklinkSharp.Client/Json/NullableItemTypeStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -58,7 +59,7 @@ namespace BricklinkSharp.Client.Json
                 return;
             }
 
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value?.ToDomainString().ToUpperInvariant();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/OrderStatusStringConverter.cs
+++ b/BricklinkSharp.Client/Json/OrderStatusStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -39,7 +40,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, OrderStatus value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/Json/PaymentStatusStringConverter.cs
+++ b/BricklinkSharp.Client/Json/PaymentStatusStringConverter.cs
@@ -26,6 +26,8 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
+using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
 {
@@ -45,7 +47,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, PaymentStatus value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString());
+            writer.WriteStringValue(value.ToDomainString());
         }
     }
 }

--- a/BricklinkSharp.Client/Json/RatingTargeRoleStringConverter.cs
+++ b/BricklinkSharp.Client/Json/RatingTargeRoleStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -40,7 +41,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, RatingTargeRole value, JsonSerializerOptions options)
         {
-            var ratingTargeRoleString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var ratingTargeRoleString = value.ToDomainString();
             writer.WriteStringValue(ratingTargeRoleString);
         }
     }

--- a/BricklinkSharp.Client/Json/RatingTypeIntConverter.cs
+++ b/BricklinkSharp.Client/Json/RatingTypeIntConverter.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using BricklinkSharp.Client.Enums;
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/BricklinkSharp.Client/Json/ShippingAreaStringConverter.cs
+++ b/BricklinkSharp.Client/Json/ShippingAreaStringConverter.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Extensions;
 
 namespace BricklinkSharp.Client.Json
@@ -50,7 +51,7 @@ namespace BricklinkSharp.Client.Json
 
         public override void Write(Utf8JsonWriter writer, ShippingArea value, JsonSerializerOptions options)
         {
-            var typeString = value.GetStringValueOrDefault().ToUpperInvariant();
+            var typeString = value.ToDomainString();
             writer.WriteStringValue(typeString);
         }
     }

--- a/BricklinkSharp.Client/NewInventory.cs
+++ b/BricklinkSharp.Client/NewInventory.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Client
 {

--- a/BricklinkSharp.Client/Notification.cs
+++ b/BricklinkSharp.Client/Notification.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/OrderBase.cs
+++ b/BricklinkSharp.Client/OrderBase.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/OrderItem.cs
+++ b/BricklinkSharp.Client/OrderItem.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 using System;
 using System.Text.Json.Serialization;

--- a/BricklinkSharp.Client/PartOutResult.cs
+++ b/BricklinkSharp.Client/PartOutResult.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using BricklinkSharp.Client.Enums;
 using System;
 using System.Text.Json.Serialization;
 

--- a/BricklinkSharp.Client/Payment.cs
+++ b/BricklinkSharp.Client/Payment.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/PriceGuide.cs
+++ b/BricklinkSharp.Client/PriceGuide.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/ShippingMethod.cs
+++ b/BricklinkSharp.Client/ShippingMethod.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Client/SuperSubSetItem.cs
+++ b/BricklinkSharp.Client/SuperSubSetItem.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 // ReSharper disable ClassNeverInstantiated.Global

--- a/BricklinkSharp.Client/SupersetEntry.cs
+++ b/BricklinkSharp.Client/SupersetEntry.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using BricklinkSharp.Client.Enums;
 using BricklinkSharp.Client.Json;
 
 namespace BricklinkSharp.Client

--- a/BricklinkSharp.Demos/CatalogDemos.cs
+++ b/BricklinkSharp.Demos/CatalogDemos.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {

--- a/BricklinkSharp.Demos/CouponDemos.cs
+++ b/BricklinkSharp.Demos/CouponDemos.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {

--- a/BricklinkSharp.Demos/FeedbackDemos.cs
+++ b/BricklinkSharp.Demos/FeedbackDemos.cs
@@ -27,6 +27,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {

--- a/BricklinkSharp.Demos/InventoryDemos.cs
+++ b/BricklinkSharp.Demos/InventoryDemos.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {

--- a/BricklinkSharp.Demos/OrderDemos.cs
+++ b/BricklinkSharp.Demos/OrderDemos.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {

--- a/BricklinkSharp.Demos/PartOutValueDemos.cs
+++ b/BricklinkSharp.Demos/PartOutValueDemos.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BricklinkSharp.Client;
 using BricklinkSharp.Client.CurrencyRates;
+using BricklinkSharp.Client.Enums;
 
 namespace BricklinkSharp.Demos
 {


### PR DESCRIPTION
**Replaced GetStringValueOrDefault() with ToDomainString().**
The replacements are less generic but negate the need of a dictionary. The dictionary was causing errors at runtime under certain conditions.

**Removed StringValue attribute and associated extensions methods.**
This reduces the use of reflection at runtime.

**Replaced most uses of Enum.ToString() with Enum.ToDomainString().**
This reduces memory allocations and runs faster.
Uses of enum values in string interpolation will still call Enum.ToString(). If possible Enum.ToDomainString() should be passed instead.