### PR TITLE
Http fixes

### DIFF
--- a/BricklinkSharp.Client/BricklinkClient.cs
+++ b/BricklinkSharp.Client/BricklinkClient.cs
@@ -571,7 +571,7 @@ internal sealed class BricklinkClient : IBricklinkClient
 
         var url = builder.ToString();
 
-        return _httpClient.PutEnsureNoResponseDataAsync(url, cancellationToken: cancellationToken);
+        return _httpClient.PostEnsureNoResponseDataAsync(url, expectedCode: 204, cancellationToken: cancellationToken);
     }
 
     public async Task<OrderDetails> UpdateOrderAsync(int orderId, UpdateOrder updateOrder,

--- a/BricklinkSharp.Client/BricklinkClient.cs
+++ b/BricklinkSharp.Client/BricklinkClient.cs
@@ -333,7 +333,7 @@ internal sealed class BricklinkClient : IBricklinkClient
         var url = new Uri(_baseUri, "inventories").ToString();
 
         return await _httpClient.PostThenReadResponseAsync<Inventory>(url, 
-            newInventory, cancellationToken);
+            newInventory, cancellationToken: cancellationToken);
     }
 
     public Task CreateInventoriesAsync(NewInventory[] newInventories, CancellationToken cancellationToken = default)
@@ -346,8 +346,8 @@ internal sealed class BricklinkClient : IBricklinkClient
         var url = new Uri(_baseUri, "inventories").ToString();
 
         return _httpClient.PostEnsureNoResponseDataAsync(url, 
-            newInventories, 
-            cancellationToken);
+            newInventories,
+            cancellationToken: cancellationToken);
     }
 
     public async Task<Inventory> UpdateInventoryAsync(int inventoryId, UpdateInventory updateInventory,
@@ -358,15 +358,15 @@ internal sealed class BricklinkClient : IBricklinkClient
 
         return await _httpClient.PutThenReadResponseAsync<Inventory>(url,
             updateInventory,
-            IgnoreNullValuesJsonSerializerOptions,
-            cancellationToken);
+            jsonSerializerOptions: IgnoreNullValuesJsonSerializerOptions,
+            cancellationToken: cancellationToken);
     }
 
     public Task DeleteInventoryAsync(int inventoryId, CancellationToken cancellationToken = default)
     {
         var url = new Uri(_baseUri, $"inventories/{inventoryId}").ToString();
 
-        return _httpClient.DeleteEnsureNoResponseDataAsync(url, cancellationToken);
+        return _httpClient.DeleteEnsureNoResponseDataAsync(url, cancellationToken: cancellationToken);
     }
 
     public Task<ItemMapping[]> GetElementIdAsync(string partNo, int? colorId, 
@@ -385,16 +385,16 @@ internal sealed class BricklinkClient : IBricklinkClient
     {
         var url = new Uri(_baseUri, $"item_mapping/{elementId}").ToString();
 
-        return await _httpClient.GetParseResponseAsync<ItemMapping[]>(url, 
-            cancellationToken);
+        return await _httpClient.GetParseResponseAsync<ItemMapping[]>(url,
+            cancellationToken: cancellationToken);
     }
 
     public Task<ShippingMethod[]> GetShippingMethodListAsync(CancellationToken cancellationToken = default)
     {
         var url = new Uri(_baseUri, "settings/shipping_methods").ToString();
 
-        return _httpClient.GetParseResponseArrayAllowEmpty<ShippingMethod>(url, 
-            cancellationToken);
+        return _httpClient.GetParseResponseArrayAllowEmpty<ShippingMethod>(url,
+            cancellationToken: cancellationToken);
     }
 
     public async Task<ShippingMethod> GetShippingMethodAsync(int methodId, CancellationToken cancellationToken = default)
@@ -409,16 +409,16 @@ internal sealed class BricklinkClient : IBricklinkClient
     {
         var url = new Uri(_baseUri, "notifications").ToString();
 
-        return _httpClient.GetParseResponseArrayAllowEmpty<Notification>(url, 
-            cancellationToken);
+        return _httpClient.GetParseResponseArrayAllowEmpty<Notification>(url,
+            cancellationToken: cancellationToken);
     }
 
     public async Task<MemberRating> GetMemberRatingAsync(string username, CancellationToken cancellationToken = default)
     {
         var url = new Uri(_baseUri, $"members/{username}/ratings").ToString();
 
-        return await _httpClient.GetParseResponseAsync<MemberRating>(url, 
-            cancellationToken);
+        return await _httpClient.GetParseResponseAsync<MemberRating>(url,
+            cancellationToken: cancellationToken);
     }
 
     public Task<Feedback[]> GetFeedbackListAsync(Direction? direction = null, 
@@ -453,8 +453,8 @@ internal sealed class BricklinkClient : IBricklinkClient
             Rating = rating
         };
 
-        return await _httpClient.PostThenReadResponseAsync<Feedback>(url, body, 
-            cancellationToken);
+        return await _httpClient.PostThenReadResponseAsync<Feedback>(url, body,
+            cancellationToken: cancellationToken);
     }
 
     public Task ReplyFeedbackAsync(int feedbackId, 
@@ -464,7 +464,7 @@ internal sealed class BricklinkClient : IBricklinkClient
         var url = new Uri(_baseUri, $"feedback/{feedbackId}/reply").ToString();
         var body = new { reply };
 
-        return _httpClient.PostEnsureNoResponseDataAsync(url, body, cancellationToken);
+        return _httpClient.PostEnsureNoResponseDataAsync(url, body, cancellationToken: cancellationToken);
     }
 
     public Task<Order[]> GetOrdersAsync(OrderDirection direction = OrderDirection.In,
@@ -546,7 +546,7 @@ internal sealed class BricklinkClient : IBricklinkClient
         {
             field = "status",
             value = status.ToDomainString()
-        }, null, cancellationToken);
+        }, cancellationToken: cancellationToken);
     }
 
     public Task UpdatePaymentStatusAsync(int orderId, PaymentStatus status, 
@@ -558,7 +558,7 @@ internal sealed class BricklinkClient : IBricklinkClient
         {
             field = "payment_status",
             value = status.ToDomainString()
-        }, null, cancellationToken);
+        }, cancellationToken: cancellationToken);
     }
 
     public Task SendDriveThruAsync(int orderId, bool mailCcMe,
@@ -580,7 +580,8 @@ internal sealed class BricklinkClient : IBricklinkClient
         var url = new Uri(_baseUri, $"orders/{orderId}").ToString();
 
         return await _httpClient.PutThenReadResponseAsync<OrderDetails>(url, updateOrder,
-            IgnoreNullValuesJsonSerializerOptions, cancellationToken);
+            jsonSerializerOptions: IgnoreNullValuesJsonSerializerOptions,
+            cancellationToken: cancellationToken);
     }
 
     public void Dispose()
@@ -622,8 +623,8 @@ internal sealed class BricklinkClient : IBricklinkClient
     {
         var url = new Uri(_baseUri, $"coupons/{couponId}").ToString();
 
-        return _httpClient.DeleteEnsureNoResponseDataAsync(url, 
-            cancellationToken);
+        return _httpClient.DeleteEnsureNoResponseDataAsync(url,
+            cancellationToken: cancellationToken);
     }
 
     public async Task<Coupon> CreateCouponAsync(NewCoupon newCoupon, CancellationToken cancellationToken = default)
@@ -633,7 +634,7 @@ internal sealed class BricklinkClient : IBricklinkClient
         var url = new Uri(_baseUri, "coupons").ToString();
 
         return await _httpClient.PostThenReadResponseAsync<Coupon>(url, newCoupon,
-            cancellationToken);
+            cancellationToken: cancellationToken);
     }
 
     public async Task<Coupon> UpdateCouponAsync(int couponId, UpdateCoupon updateCoupon, 
@@ -645,8 +646,8 @@ internal sealed class BricklinkClient : IBricklinkClient
 
         return await _httpClient.PutThenReadResponseAsync<Coupon>(url,
             updateCoupon,
-            IgnoreNullValuesJsonSerializerOptions,
-            cancellationToken);
+            jsonSerializerOptions: IgnoreNullValuesJsonSerializerOptions,
+            cancellationToken: cancellationToken);
     }
 
     public async Task<PartOutResult> GetPartOutValueFromPageAsync(string itemNo, Condition condition = Condition.New,

--- a/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
+++ b/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
@@ -174,19 +174,24 @@ internal static class HttpClientExtensions
     }
 
     public static Task<TResponse> PutThenReadResponseAsync<TResponse>(this HttpClient httpClient,
-        string url, object? body = null,
+        string url, 
+        object? body = null, 
+        int expectedCode = 200,
         JsonSerializerOptions? jsonSerializerOptions = null,
         CancellationToken cancellationToken = default)
     {
         return ExecuteReadResponseAsync<TResponse>(httpClient,
-            HttpMethod.Put, url, 200, body, jsonSerializerOptions, cancellationToken);
+            HttpMethod.Put, url, expectedCode, body, jsonSerializerOptions, cancellationToken);
     }
 
     public static Task PutEnsureNoResponseDataAsync(this HttpClient httpClient,
-        string url, object? body = null, JsonSerializerOptions? jsonSerializerOptions = null,
+        string url, 
+        object? body = null, 
+        int expectedCode = 200,
+        JsonSerializerOptions? jsonSerializerOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Put, 200, body, jsonSerializerOptions,
+        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Put, expectedCode, body, jsonSerializerOptions,
             cancellationToken);
     }
 
@@ -194,23 +199,29 @@ internal static class HttpClientExtensions
         this HttpClient httpClient,
         string url,
         object body,
-        CancellationToken cancellationToken)
+        int expectedCode = 201,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteReadResponseAsync<TResponse>(httpClient, 
-            HttpMethod.Post, url, 201, body, null, cancellationToken);
+            HttpMethod.Post, url, expectedCode, body, null, cancellationToken);
     }
 
     public static Task PostEnsureNoResponseDataAsync(this HttpClient httpClient,
-        string url, object? body = null, CancellationToken cancellationToken = default)
+        string url, 
+        object? body = null, 
+        int expectedCode = 201,
+        CancellationToken cancellationToken = default)
     {
-        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Post, 201, body, null,
+        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Post, expectedCode, body, null,
             cancellationToken);
     }
 
     public static Task DeleteEnsureNoResponseDataAsync(this HttpClient httpClient,
-        string url, CancellationToken cancellationToken = default)
+        string url, 
+        int expectedCode = 204,
+        CancellationToken cancellationToken = default)
     {
-        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Delete, 204, 
+        return ExecuteEnsureNoResponse(httpClient, url, HttpMethod.Delete, expectedCode, 
             null, 
             null,
             cancellationToken);

--- a/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
+++ b/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
@@ -154,7 +154,7 @@ internal static class HttpClientExtensions
         if (body != null)
         {
             var json = JsonSerializer.Serialize(body, options);
-            using var content = new StringContent(json, Encoding.Default, "application/json");
+            var content = new StringContent(json, Encoding.Default, "application/json");
             content.Headers.ContentType.CharSet = string.Empty;
             message.Content = content;
         }

--- a/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
+++ b/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
@@ -187,7 +187,7 @@ internal static class HttpClientExtensions
     public static Task PutEnsureNoResponseDataAsync(this HttpClient httpClient,
         string url, 
         object? body = null, 
-        int expectedCode = 200,
+        int expectedCode = 204,
         JsonSerializerOptions? jsonSerializerOptions = null,
         CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
I wanted to fix issue #7, but when I checked out the code I ran into an 'object disposed' problem for the `StrongContent` set in the HttpRequestMessage. According to https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System/net/System/Net/Http/HttpRequestMessage.cs#L200 the Content property is automatically disposed when the `HttpRequestMessage` is disposed. So to fix that, I removed the '`using`' keyword.

`SendDriveThruAsync` was indeed the odd one out. Actually, the documentation states that the endpoint should be called with a POST method, instead of a PUT. So I changed that and because that call resulted in a 204 instead of the 201 that was normally expected, I did add an optional '`expectedCode`' parameter in the HttpClient extension methods.

Last but not least, I changed the default expected code for `PutEnsureNoResponseData` to 204 and got #7 fixed.


Hope this helps!

