### PR TITLE
GetPartOutValueFromPageAsync for >$1k sets returns just thousands as single digit

### DIFF
--- a/BricklinkSharp.Client/PartOutResponseParser.cs
+++ b/BricklinkSharp.Client/PartOutResponseParser.cs
@@ -106,7 +106,7 @@ internal static class PartOutResponseParser
     private static readonly Regex _partOutCurrentSales = new Regex("<FONT CLASS=\"fv\">Current Items For Sale Average:<\\/FONT>.+?<\\/B>",
         RegexOptions.IgnoreCase);
     private static readonly Regex _withinBTags = new Regex("(?<=<B>)(.*)(?=<\\/B>)", RegexOptions.IgnoreCase);
-    private static readonly Regex _decimal = new Regex("\\d+\\.?\\d*");
+    private static readonly Regex _decimal = new Regex("\\d{1,3}(?:,?\\d{3})*(?:\\.\\d{2})");
     private static readonly Regex _number = new Regex("\\d+");
     private static readonly CultureInfo _enUs = new CultureInfo("en-US");
     private static readonly Regex _included = new Regex("<FONT CLASS=\"fv\">Including <B>\\d+<\\/B> Item[s]? in <B>\\d+<\\/B> Lot[s]?.", 


### PR DESCRIPTION
Well, maybe an example will show what I mean:
![image](https://github.com/gebirgslok/BricklinkSharp/assets/4960972/f9a8d06d-c64d-4ad2-bf99-67be46212441)

If the part out value is above $1,000.00 then the code cuts hundreds, and it's returned as $1

My PR fixes the regex for decimals. I didn't run the code, I've tested the regex with regex101.com.

Example sets with the issue:
10307
75313

Issue: #22 