### PR TITLE
Non-null description

### DIFF
--- a/BricklinkSharp.Client/UpdateInventory.cs
+++ b/BricklinkSharp.Client/UpdateInventory.cs
@@ -40,7 +40,7 @@ public class UpdateInventory
     public decimal? UnitPrice { get; set; }
 
     [JsonPropertyName("description")]
-    public string? Description { get; set; }
+    public string Description { get; set; } = String.Empty;
 
     [JsonPropertyName("remarks")]
     public string? Remarks { get; set; }


### PR DESCRIPTION
Making sure that description field is not null.

It appears that the description field is mandatory and shall not be null. I have no idea if this is a new rule at Bricklink or it just wasn't visible for me yet.