### PR TITLE
Fix credentials passed as body in GetParseResponseArrayAllowEmpty

### DIFF
--- a/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
+++ b/BricklinkSharp.Client/Extensions/HttpClientExtensions.cs
@@ -312,10 +312,10 @@ internal static class HttpClientExtensions
     {
         var method = HttpMethod.Get;
 
-        var responseBody = await httpClient.ExecuteRequestAsync(url, 
+        var responseBody = await httpClient.ExecuteRequestAsync(url,
             method,
-            credentials,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken,
+            credentials: credentials);
 
         var dataArray = ParseResponseArrayAllowEmpty<TResponse>(responseBody, 200, url, method);
         return dataArray;


### PR DESCRIPTION
## Summary

- `GetParseResponseArrayAllowEmpty<TResponse>` was passing `credentials` as the third positional argument to `ExecuteRequestAsync`, which mapped it to the `body` parameter instead of `credentials`
- Requests made via this method were sent without an `Authorization` header and with the `BricklinkCredentials` object serialized as the HTTP request body
- Fixed by using named parameters to route arguments correctly

## Root Cause

```csharp
// Before (buggy): credentials lands in `body` slot
var responseBody = await httpClient.ExecuteRequestAsync(url, 
    method,
    credentials,                          // <- 3rd positional arg = body
    cancellationToken: cancellationToken);

// After (fixed): credentials routed to correct named parameter
var responseBody = await httpClient.ExecuteRequestAsync(url,
    method,
    cancellationToken: cancellationToken,
    credentials: credentials);
```

## Test plan

- [x] `dotnet build` — no errors or warnings
- [x] `dotnet test` — 64/66 tests pass (2 pre-existing failures unrelated to this change: `GetPartOutValueAsync_WithExchangeRate_*` require an Exchangeratesapi.io API key not present in the test environment)

Closes #28